### PR TITLE
removing reference to non-existing image

### DIFF
--- a/resources/css/fundocs.css
+++ b/resources/css/fundocs.css
@@ -44,7 +44,7 @@ select[name='module'] {
 
 .module .module-head {
     padding: 4px 0;
-    background: #E0E0E0 url(../images/noise.png);
+    background-color: #E0E0E0;
 }
 
 .module .module-head-inner {


### PR DESCRIPTION
This causes an error in Firefox on Mac OS, but other browsers appear to cope with it, only adding the grey background.
