### PR TITLE
Align with monex's travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
 language: java
 
-jdk:
-  - oraclejdk8
-  - oraclejdk9
+dist: xenial
 
-script: mvn -B test package
+matrix:
+  include:
+    - jdk: openjdk8
+    - jdk: openjdk9
+    - jdk: openjdk10
+    - jdk: openjdk11
+    - jdk: openjdk12
 
-notifications:
-  slack: exist-db:IXzUdqA0n11cnxaDz43ZQgdX
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION
As suggested by @duncdrum:

> TLDR; switch to OpenJDK8 on travis, the message you posted tried to install oraclejdk8 you can find the proper syntax in other app repos like monex
 
I consulted the syntax in https://github.com/eXist-db/monex/blob/master/.travis.yml. 