### PR TITLE
Include compiled page template to fix navigation.

### DIFF
--- a/xar-assembly.xml
+++ b/xar-assembly.xml
@@ -60,10 +60,17 @@
             -->
             <exclude>**.js</exclude>
             <exclude>**.css</exclude>
+            <exclude>**/page.html</exclude>
           </excludes>
         </fileSet>
         <fileSet>
           <directory>${project.build.directory}/generated-resources/frontend/xar-resources</directory>
+        </fileSet>
+        <fileSet>
+          <directory>${project.build.directory}/classes</directory>
+          <includes>
+            <include>templates/page.html</include>
+        </includes>
         </fileSet>
   </fileSets>
 


### PR DESCRIPTION
This is a proposal to fix issue #16 - it includes the compiled page.html template in the resulting xar instead of the uncompiled version from `/src/main/xar-resources/templates`.