### PR TITLE
Fix type promotion error

### DIFF
--- a/src/main/xar-resources/modules/view.xql
+++ b/src/main/xar-resources/modules/view.xql
@@ -12,7 +12,7 @@ let $config := map {
     $templates:CONFIG_APP_ROOT : $config:app-root,
     $templates:CONFIG_STOP_ON_ERROR : true()
 }
-let $resolve := function($func as xs:string, $arity as xs:int) {
+let $resolve := function($func as xs:string, $arity as xs:integer) {
     try {
         function-lookup(xs:QName($func), $arity)
     } catch * {


### PR DESCRIPTION
The function-lookup function’s 2nd parameter takes xs:integer, and XQuery’s type promotion rules prevent promoting xs:int to xs:integer.

See https://github.com/eXist-db/templating/pull/18.