### PR TITLE
Prevent FORX0003 error - could match empty string

### DIFF
--- a/src/main/xar-resources/modules/app.xql
+++ b/src/main/xar-resources/modules/app.xql
@@ -297,7 +297,7 @@ declare %private function app:print-parameters($params as element(xqdoc:param)*)
 };
 
 declare %private function app:get-extended-doc($function as element(xqdoc:function)) {
-    let $name := replace($function/xqdoc:name, "([^:]+:)?(.*)$", "$2")
+    let $name := replace($function/xqdoc:name, "([^:]+:)?(.+)$", "$2")
     let $arity := count($function/xqdoc:comment/xqdoc:param)
     let $prefix := $function/ancestor::xqdoc:xqdoc/xqdoc:module/xqdoc:name
     let $prefix := if ($prefix/text()) then $prefix else "fn"


### PR DESCRIPTION
This PR prevents a `err:FORX0003` error from being raised when using eXist 7.0.0-SNAPSHOT (HEAD).

> err:FORX0003 regular expression could match empty string

Required after the merge of https://github.com/eXist-db/exist/pull/4864 (fixing https://github.com/eXist-db/exist/issues/3803).