### PR TITLE
ci(bats): bump timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         timeout-minutes: 5
         run: |
           while ! docker logs exist | grep -q "Server has started"; \
-          do sleep 4s; \
+          do sleep 6s; \
           done
 
       # Test


### PR DESCRIPTION
test is a bit flaky as checks can run too early