### PR TITLE
fix(documentation): add ngram-index to the list of indexes

### DIFF
--- a/src/main/xar-resources/data/docs/util/index-keys_5.md
+++ b/src/main/xar-resources/data/docs/util/index-keys_5.md
@@ -46,7 +46,7 @@ had been defined (otherwise nothing will be returned).
 
 # Index names
 
-The default names for indexes are as follows (some of them can be found in the eXist-db `config.xml` file under `eixst/indexer/modules` element):
+The default names for indexes are as follows (some of them can be found in the eXist-db `conf.xml` file under `exist/indexer/modules` element):
 
 Name|Index
 ----|-----

--- a/src/main/xar-resources/data/docs/util/index-keys_5.md
+++ b/src/main/xar-resources/data/docs/util/index-keys_5.md
@@ -46,10 +46,11 @@ had been defined (otherwise nothing will be returned).
 
 # Index names
 
-The default names for indexes are as follows:
+The default names for indexes are as follows (some of them can be found in the eXist-db `config.xml` file under `eixst/indexer/modules` element):
 
 Name|Index
 ----|-----
 structural-index|Structural index
 lucene-index|Lucene-based full text index
 range-index|New range index
+ngram-index|N-gram index


### PR DESCRIPTION
Added missing n-gram index name to the table of available/defined indexes (used with ` util:index-keys` function).