### PR TITLE
docs: update README for Node-based build and automated releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,61 @@
 # eXist-db Function Documentation Browser App
 
-[![CI](https://github.com/eXist-db/function-documentation/actions/workflows/ci.yml/badge.svg)](https://github.com/eXist-db/function-documentation/actions/workflows/ci.yml)
+[![Build](https://github.com/eXist-db/function-documentation/actions/workflows/build.yml/badge.svg)](https://github.com/eXist-db/function-documentation/actions/workflows/build.yml)
 [![eXist-db version](https://img.shields.io/badge/eXist_db-6.2.0-blue.svg)](http://www.exist-db.org/exist/apps/homepage/index.html)
 
 <img src="src/main/xar-resources/icon.png" align="left" width="15%"/>
 
-This repository contains the function documentation browser app for the [eXist-db native XML database](http://www.exist-db.org).
+This repository contains the source code for the Function Documentation application for the [eXist-db native XML database](https://exist-db.org).
 
 ## Dependencies
 
-- [Maven](https://maven.apache.org): `3.5.2`
-- [eXist-db](http://exist-db.org): `6.2.0`
+- [Node.js](https://nodejs.org): LTS
+- [eXist-db](https://exist-db.org): `6.2.0` or later
 
 ## Installation
 
-- Just go to your eXist server's Dashboard and select Function Documentation.
-- Update to the latest release via the eXist-db package manager or via the eXist-db.org public app repository at [http://exist-db.org/exist/apps/public-repo/](http://exist-db.org/exist/apps/public-repo/).
+- Function Documentation is installed by default in the eXist distribution. Just go to your eXist server's Dashboard and select Function Documentation.
+- Update to the latest release via Dashboard > Package Manager, or download a release via the exist-db.org public app repository at [https://exist-db.org/exist/apps/public-repo/](https://exist-db.org/exist/apps/public-repo/).
 
 ## Building from source
 
 1. Clone the repository to your system:
 
    ```bash
-   git clone https://github.com/exist-db/function-documentation.git
+   git clone https://github.com/eXist-db/function-documentation.git
+   cd function-documentation
    ```
 
-2. Build the function documentation application:
+2. Install dependencies and build the application package (`.xar` file):
 
    ```bash
-   cd function-documentation
-   mvn clean package
+   npm ci
+   npm run build
    ```
 
-   The compiled `.xar` file is located in the `/target` directory
+   The package is written to `dist/exist-function-documentation-<version>.xar`. On a fresh clone, `<version>` will be the placeholder in `package.json` (the real version is set in-memory on the CI runner during the release pipeline).
 
-3. Install this file via the Dashboard > Package Manager.
+3. Install the package via Dashboard > Package Manager.
+
+For local development against a running eXist-db, use `npm run develop` (live-reload) and `npm run deploy` (install the built package into the configured eXist-db instance — set credentials in `.env`, see `.env.example`).
+
+## Release Procedure
+
+Releases are fully automated: every push to `master` triggers [semantic-release](https://semantic-release.gitbook.io/), which computes the next version from [Conventional Commits](https://www.conventionalcommits.org/) since the last tag, builds the package, and publishes a GitHub Release with the package attached at [https://github.com/eXist-db/function-documentation/releases](https://github.com/eXist-db/function-documentation/releases).
+
+### What contributors need to do
+
+- **Write [Conventional Commits](https://www.conventionalcommits.org/).** A `commitlint` + `husky` `commit-msg` hook enforces this locally (`@commitlint/config-conventional`). The commit type determines the version bump:
+  - `feat:` → minor bump
+  - `fix:`, `perf:` → patch bump
+  - any commit with a `BREAKING CHANGE:` footer or a `!` after the type (e.g. `feat!:`) → major bump
+  - `chore:`, `docs:`, `ci:`, `build:`, `style:`, `refactor:`, `test:` → no release (cosmetic / housekeeping)
+- That's it. No version bump, no tag creation, no manual release commit.
+
+### What release managers need to do
+
+Pushes to `master` are released automatically. If the release pipeline fails (check the `Release` job in the [Actions tab](https://github.com/eXist-db/function-documentation/actions)) the commit history is still intact, and re-running the job is safe, since semantic-release is idempotent.
 
 ## License
 
-LGPLv2.1 [eXist-db.org](http://exist-db.org/exist/apps/homepage/index.html)
+LGPL v2.1 [exist-db.org](https://exist-db.org/exist/apps/homepage/index.html)


### PR DESCRIPTION
[This response was co-authored with Claude Code. -Joe]

Closes #191.

The README still documented the old Maven flow after #183 landed. Updates:

- Fix CI badge: the workflow file was renamed `ci.yml` → `build.yml` in #183, so the existing badge was 404ing on master
- Replace Maven build instructions with the Node-based flow (\`npm ci && npm run build\`); call out \`dist/exist-function-documentation-<version>.xar\` as the output path and \`npm run develop\` / \`npm run deploy\` for local iteration
- Add a Release Procedure section explaining the semantic-release pipeline, the conventional-commit format expected from contributors, and what release managers need to do (nothing routine — pushes to master are released automatically)
- Tidy installation + dependency wording

This was originally intended as part of #183 but didn't make it in before the merge — opening as a standalone follow-up.