### PR TITLE
fix(release): tidy up auto-generated changelog items

### DIFF
--- a/scripts/update-repo-changelog.js
+++ b/scripts/update-repo-changelog.js
@@ -28,6 +28,9 @@ const SECTION_PREFIX = {
   Reverts: 'Revert'
 }
 
+// Render the scope (when present) as a parenthesised qualifier on the prefix:
+// "Fix (documentation): add ngram-index..." rather than the awkward double-colon
+// "Fix: documentation: add ngram-index...".
 const XML_MAIN_TEMPLATE =
   '{{#each noteGroups}}' +
   '{{#each notes}}' +
@@ -36,9 +39,27 @@ const XML_MAIN_TEMPLATE =
   '{{/each}}' +
   '{{#each commitGroups}}' +
   '{{#each commits}}' +
-  '{{#unless isBreaking}}<li>{{prefix}}: {{#if scope}}{{scope}}: {{/if}}{{subject}}</li>\n{{/unless}}' +
+  '{{#unless isBreaking}}<li>{{prefix}}{{#if scope}} ({{scope}}){{/if}}: {{subject}}</li>\n{{/unless}}' +
   '{{/each}}' +
   '{{/each}}'
+
+/**
+ * Tidy up a commit-derived <li> text node for display in the in-app changelog.
+ *
+ *  - Collapse hard-wrapped newlines from the commit body (which would otherwise
+ *    break the sentence mid-line in the rendered <li>).
+ *  - Strip backslash-escapes that immediately precede backticks. Commit bodies
+ *    written via shell heredocs sometimes end up with literal `\`` sequences
+ *    in the stored message; they're meaningless once the text reaches an HTML
+ *    list item.
+ *  - Collapse consecutive whitespace and trim.
+ */
+function normalizeItem (text) {
+  return text
+    .replace(/\\`/g, '`')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
 
 function parseArgs () {
   return Object.fromEntries(
@@ -108,7 +129,7 @@ async function buildChangeItems (rawCommits, version) {
   const liNodes = doc.getElementsByTagNameNS(HTML_NS, 'li')
   const items = []
   for (let i = 0; i < liNodes.length; i++) {
-    const text = liNodes.item(i).textContent
+    const text = normalizeItem(liNodes.item(i).textContent || '')
     if (text) items.push(text)
   }
   return items


### PR DESCRIPTION
[This PR was co-authored with Claude Code. -Joe]

Three cosmetic bugs surfaced in v3.0.0's bundled `repo.xml` changelog (visible to users browsing the package's Changelog tab in Dashboard > Package Manager):

1. **Scope rendered awkwardly.** `fix(documentation): add ngram-index...` came out as `Fix: documentation: add ngram-index...` (double colon, repeated noise). Now: `Fix (documentation): add ngram-index...`.
2. **Hard-wrapped commit bodies broke mid-sentence.** A `BREAKING CHANGE:` footer split across two source lines rendered with a literal newline inside the `<li>`. Now collapsed to a single space.
3. **Backslash-escapes leaked through.** Bodies authored via shell heredocs sometimes carry literal `` \` `` pairs from `<<'EOF'` heredoc handling; stripped now since they're meaningless once they reach HTML.

Verified by re-running `update-repo-changelog.js --version=3.0.1 --prev-tag=2.1.1` against the actual v3.0.0..master commit history; the generated `<change version="3.0.1">` entry now reads cleanly:

```xml
<change version="3.0.1">
    <ul xmlns="http://www.w3.org/1999/xhtml">
        <li>Breaking change: builds now require Node.js (lts/*) instead of Maven. Use `npm ci &amp;&amp; npm run build` to produce the XAR.</li>
        <li>Fix (documentation): add ngram-index to the list of indexes</li>
    </ul>
</change>
```

(`&amp;&amp;` is the XML-escaped form; the in-app changelog renders it as the literal `&&`.)

When this merges, semantic-release will tag v3.0.1 (the `fix:` prefix triggers a patch bump). Since master already has the README update from #192, v3.0.1's `.xar` will pick that up automatically — bundled changelog *and* bundled README will both be current, ready to publish to exist-db.org public-repo.