### PR TITLE
docs(changelog): backport v3.0.0 auto-generated items into repo.xml.tmpl

### DIFF
--- a/repo.xml.tmpl
+++ b/repo.xml.tmpl
@@ -13,6 +13,8 @@
     <changelog>
         <change version="3.0.0">
             <ul xmlns="http://www.w3.org/1999/xhtml">
+                <li>Breaking change: replace the Maven build with Node.js / Gulp / semantic-release. Building from source now requires Node.js (LTS) instead of Maven - <a href="https://github.com/eXist-db/function-documentation/pull/183">#183</a></li>
+                <li>Add ngram-index to the list of indexes - <a href="https://github.com/eXist-db/function-documentation/pull/152">#152</a></li>
                 <li>Rewrite search queries to avoid parenthesised-step slow path - <a href="https://github.com/eXist-db/function-documentation/pull/178">#178</a></li>
             </ul>
         </change>


### PR DESCRIPTION
[This response was co-authored with Claude Code. -Joe]

After v3.0.1 was published to exist-db.org's public-repo, the changelog tab for fundocs ([link](https://exist-db.org/exist/apps/public-repo/packages/fundocs?eXist-db-min-version=6.2.0)) showed v3.0.0 with only one bullet — the hand-authored "Rewrite search queries" line from #178 — even though v3.0.0's own `.xar` had also listed the BREAKING CHANGE de-mavenize headline and the `fix(documentation):` ngram-index item.

The cause is structural: `scripts/update-repo-changelog.js` runs in-memory on the release runner and the modified `repo.xml.tmpl` is never committed back to master (monex-style `0.0.0-development` flow). So when v3.0.1 was released, its `.xar` regenerated `repo.xml` from the hand-authored template, which only knew about the #178 line for v3.0.0. Public-repo renders the latest `.xar`'s changelog, so the older release rows got retroactively thinned out.

This PR folds the missing v3.0.0 items into the hand-authored `<change version="3.0.0">` block in `repo.xml.tmpl`, so any subsequent release (v3.0.2+) will ship a fuller v3.0.0 row, and public-repo's display will recover the full context the next time a new release is uploaded.

The `docs:` prefix means this commit on its own won't trigger a release; the backport will surface to public-repo whenever the next `fix:` / `feat:` PR lands.